### PR TITLE
Update the imported target Java package name

### DIFF
--- a/configpanel/src/com/cyanogenmod/settings/device/utils/NodePreferenceActivity.java
+++ b/configpanel/src/com/cyanogenmod/settings/device/utils/NodePreferenceActivity.java
@@ -27,8 +27,8 @@ import android.view.MenuItem;
 
 import java.io.File;
 
-import org.mokee.internal.util.FileUtils;
-import org.mokee.internal.util.ScreenType;
+import org.cyanogenmod.internal.util.FileUtils;
+import org.cyanogenmod.internal.util.ScreenType;
 
 public class NodePreferenceActivity extends PreferenceActivity
         implements OnPreferenceChangeListener {


### PR DESCRIPTION
* To import the jar package by default: org.cyanogenmod.internal.util.*
* rather than import org.mokee.internal.util.*

Signed-off-by: evilgodex <evilghostex@foxmail.com>